### PR TITLE
Fix issue when adjust_time not defined

### DIFF
--- a/fingertip/plugins/cleanup.py
+++ b/fingertip/plugins/cleanup.py
@@ -67,7 +67,7 @@ def machines(expired_for=0):
             lock.acquire()
             try:
                 remove = fingertip.machine.needs_a_rebuild(d, by=adjusted_time)
-            except (FileNotFoundError, EOFError):
+            except (FileNotFoundError, EOFError, UnboundLocalError):
                 remove = True
             if (expired_for == 'all' or remove):
                 assert os.path.realpath(d).startswith(path.MACHINES)


### PR DESCRIPTION
Sometimes I hit this if I try to cleanup everything ...

```shell
$ fingertip cleanup everything
fingertip: removing /home/mvadkert/.cache/fingertip/logs/plugins.os.fedora.install_in_qemu-2020-03-27T21:44:19.057768.txt
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mvadkert/git/github.com/fingertip/fingertip/main.py", line 34, in main
    m = fingertip.build(first_step_cmd, *first_step_args, **first_step_kwargs)
  File "/home/mvadkert/git/github.com/fingertip/fingertip/machine.py", line 206, in build
    first = func(*args, **kwargs)
  File "/home/mvadkert/git/github.com/fingertip/fingertip/machine.py", line 18, in wrapper
    r = func(*a, **kwa)
  File "/home/mvadkert/git/github.com/fingertip/fingertip/plugins/cleanup.py", line 24, in main
    return everything()
  File "/home/mvadkert/git/github.com/fingertip/fingertip/plugins/cleanup.py", line 88, in everything
    machines('all')
  File "/home/mvadkert/git/github.com/fingertip/fingertip/plugins/cleanup.py", line 69, in machines
    remove = fingertip.machine.needs_a_rebuild(d, by=adjusted_time)
UnboundLocalError: local variable 'adjusted_time' referenced before assignment
```

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>