### PR TITLE
simple selftest making sure hostname is set to sensible values

### DIFF
--- a/fingertip/plugins/self_test/hostname.py
+++ b/fingertip/plugins/self_test/hostname.py
@@ -1,0 +1,12 @@
+# Licensed under GNU General Public License v3 or later, see COPYING.
+# Copyright (c) 2020 Red Hat, Inc., see CONTRIBUTORS.
+
+import fingertip
+
+@fingertip.transient
+def main(m):
+    with m.transient() as m:
+        r = m('hostname')
+        assert r.out.endswith('.fingertip.local\n')
+        assert m('hostname -d').out == 'fingertip.local\n'
+


### PR DESCRIPTION
Simple test invoking `hostname` with various arguments, making sure it is set to expected values.