### PR TITLE
Do not try to change permission of a key we do not own

### DIFF
--- a/fingertip/plugins/backend/qemu.py
+++ b/fingertip/plugins/backend/qemu.py
@@ -384,8 +384,12 @@ class SSH:
     @property
     def key_file(self):
         key_file = path.fingertip('ssh_key', 'fingertip')
-        mode = os.stat(key_file)[stat.ST_MODE]
-        if mode & 0o77:
+        s = os.stat(key_file)
+        mode = s[stat.ST_MODE]
+        owner = s[stat.ST_UID]
+        # OpenSSH cares about permissions on key file only if the owner
+        # matches current user
+        if mode & 0o77 and owner == os.getuid():
             self.m.log.debug(f'fixing up permissions on {key_file}')
             os.chmod(key_file, mode & 0o7700)
         return key_file


### PR DESCRIPTION
The OpenSSH does not care about permissions in case the file
is not owned by the current user.

This is useful when fingertip is installed systemwide in non-writable
parse of filesystem.