### PR TITLE
Setup & cleanup procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ In practice, this probably means either `btrfs` or specially-created `xfs`
 
 ``` bash
 $ mkdir -p ~/.cache/fingertip/machines
-$ fallocate -l 20G ~/.cache/fingertip/machines/for-machines.xfs
-$ mkfs.xfs -m reflink=1 ~/.cache/fingertip/machines/for-machines.xfs
-$ sudo mount -o loop ~/.cache/fingertip/machines/for-machines.xfs ~/.cache/fingertip/machines
+$ fallocate -l 20G ~/.cache/fingertip/for-machines.xfs
+$ mkfs.xfs -m reflink=1 ~/.cache/fingertip/for-machines.xfs
+$ sudo mount -o loop ~/.cache/fingertip/for-machines.xfs ~/.cache/fingertip/machines
 $ sudo chown $USER ~/.cache/fingertip/machines
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,15 @@ you need a CoW-enabled filesystem on your `~/.cache/fingertip/machines`.
 In practice, this probably means either `btrfs` or specially-created `xfs`
 (see example below):
 
+When you first run `fingertip`, the interactive setup wizard will create
+all of this for you, which should cover most of the common use cases.
+In case you need to automate the setup, you can use the environment
+variables `FINGERTIP_SETUP=auto|suggest|never` and `FINGERTIP_SETUP_SIZE`
+or perform the setup manualy:
+
 ``` bash
 $ mkdir -p ~/.cache/fingertip/machines
-$ fallocate -l 20G ~/.cache/fingertip/for-machines.xfs
+$ fallocate -l 25G ~/.cache/fingertip/for-machines.xfs
 $ mkfs.xfs -m reflink=1 ~/.cache/fingertip/for-machines.xfs
 $ sudo mount -o loop ~/.cache/fingertip/for-machines.xfs ~/.cache/fingertip/machines
 $ sudo chown $USER ~/.cache/fingertip/machines

--- a/fingertip/main.py
+++ b/fingertip/main.py
@@ -25,17 +25,12 @@ def parse_subcmd(subcmd, *all_args):
 
 
 def main():
-    fingertip.util.log.nicer()
+    # Start with plain to get output from setup wizard
+    fingertip.util.log.plain()
 
-    # warn if there is no reflink support
-    path = fingertip.util.path.MACHINES
-    fingertip.util.log.debug(f"checking reflink support for {path}")
-    if not fingertip.util.reflink.is_supported(path):
-        fingertip.util.log.warning(
-            f"Reflink not supported for machines directory ('{path}'), "
-            f"Copy-on-Write not possible, YOU DON'T WANT THIS! "
-            f"See README.md, section 'CoW' on why and how to enable it."
-        )
+    fingertip.util.reflink.storage_setup_wizard()
+
+    fingertip.util.log.nicer()
 
     args = sys.argv[1:]
 

--- a/fingertip/plugins/cleanup.py
+++ b/fingertip/plugins/cleanup.py
@@ -22,6 +22,8 @@ def main(what=None, older_than=0):
         return
     if what == 'everything':
         return everything()
+    if what == 'periodic':
+        return periodic()
     elif what in ('downloads', 'logs', 'machines'):
         return globals()[what](older_than)
     log.error('usage: ')
@@ -29,6 +31,7 @@ def main(what=None, older_than=0):
     log.error('    fingertip cleanup logs [<older-than>]')
     log.error('    fingertip cleanup machines [<expired-for>|all]')
     log.error('    fingertip cleanup everything')
+    log.error('    fingertip cleanup periodic')
     raise SystemExit()
 
 
@@ -80,6 +83,10 @@ def machines(expired_for=0):
                 log.debug(f'keeping {os.path.realpath(d)}')
             os.unlink(lock_path)
             lock.release()
+
+
+def periodic():
+    machines('12h')
 
 
 def everything():

--- a/fingertip/plugins/filesystem.py
+++ b/fingertip/plugins/filesystem.py
@@ -9,10 +9,11 @@ from fingertip.util import log, filesystem
 
 @fingertip.transient
 def main(what=None):
-    if what in ('setup', 'cleanup'):
+    if what in ('setup', 'unmount', 'cleanup'):
         return globals()[what]()
     log.error('usage: ')
     log.error('    fingertip filesystem setup')
+    log.error('    fingertip filesystem unmount')
     log.error('    fingertip filesystem cleanup')
     raise SystemExit()
 
@@ -21,5 +22,9 @@ def setup():
     filesystem.storage_setup_wizard()
 
 
-def cleanup():
+def unmount():
     filesystem.storage_unmount()
+
+
+def cleanup():
+    filesystem.storage_destroy()

--- a/fingertip/plugins/filesystem.py
+++ b/fingertip/plugins/filesystem.py
@@ -1,0 +1,25 @@
+# Licensed under GNU General Public License v3 or later, see COPYING.
+# Copyright (c) 2020 Red Hat, Inc., see CONTRIBUTORS.
+
+import os
+
+import fingertip.machine
+from fingertip.util import log, filesystem
+
+
+@fingertip.transient
+def main(what=None):
+    if what in ('setup', 'cleanup'):
+        return globals()[what]()
+    log.error('usage: ')
+    log.error('    fingertip filesystem setup')
+    log.error('    fingertip filesystem cleanup')
+    raise SystemExit()
+
+
+def setup():
+    filesystem.storage_setup_wizard()
+
+
+def cleanup():
+    filesystem.storage_unmount()

--- a/fingertip/util/hooks.py
+++ b/fingertip/util/hooks.py
@@ -1,5 +1,5 @@
 """
-Helper functions for fingertep: attacking and calling hooks.
+Helper functions for fingertip: attaching and calling hooks.
 """
 
 import collections

--- a/fingertip/util/reflink.py
+++ b/fingertip/util/reflink.py
@@ -115,7 +115,7 @@ def storage_unmount():
 def storage_schedule_cleanup():
     # Do this only if fingertip is in PATH
     if not shutil.which("fingertip"):
-        log.warning('No `fingertip` found in PATH. Not scheduling '
+        log.debug('No `fingertip` found in PATH. Not scheduling '
                     'automatic cleanup.')
         return
 
@@ -131,8 +131,8 @@ def storage_schedule_cleanup():
         subprocess.run(['systemctl', '--user', 'is-active', '--quiet',
                        'fingertip-cleanup.timer'])
         # exit code 0:
-        log.info('The systemd timer handling cleanup is already installed '
-                 'and running.')
+        log.debug('The systemd timer handling cleanup is already installed '
+                  'and running.')
         return
     except CalledProcessError as e:
         # non-zero exit code means it is not active or not existing

--- a/fingertip/util/reflink.py
+++ b/fingertip/util/reflink.py
@@ -112,6 +112,18 @@ def storage_unmount():
     log.nicer()
 
 
+def storage_destroy():
+    backing_file = os.path.join(CACHE, 'for-machines.xfs')
+    if os.path.exists(backing_file):
+        # we should not remove the file if it is mounted
+        mount = subprocess.run(['mount'], capture_output=True)
+        if backing_file in mount.stdout:
+            log.warning('Filesystem is still mounted. Try to unmount.')
+            storage_unmount()
+
+    os.unlink(backing_file)
+
+
 def storage_schedule_cleanup():
     # Do this only if fingertip is in PATH
     if not shutil.which("fingertip"):

--- a/fingertip/util/reflink.py
+++ b/fingertip/util/reflink.py
@@ -6,9 +6,17 @@ Helper functions and constants for fingertip: reflinking (CoW-powered copying).
 """
 # TODO: clean up even more?
 
+import os
+import sys
+import shutil
 import subprocess
 
 from fingertip.util import log, temp
+from fingertip.util.path import MACHINES, CACHE
+
+
+SETUP = os.getenv('FINGERTIP_SETUP', 'suggest')
+SIZE = os.getenv('FINGERTIP_SETUP_SIZE', '25G')
 
 
 def always(src, dst):
@@ -30,3 +38,108 @@ def is_supported(dirpath):
     if r.returncode and not sure_not:
         log.error('reflink support detection inconclusive, cache dir problems')
     return r.returncode == 0
+
+
+def create_supported_fs(backing_file, size):
+    subprocess.run(['fallocate', '-l', size, backing_file], check=True)
+    subprocess.run(['mkfs.xfs', '-m', 'reflink=1', backing_file],
+                   check=True)
+
+
+def mount_supported_fs(backing_file, tgt):
+    log.info('mounting a reflink-supported filesystem for image storage...')
+    tgt_uid, tgt_gid = os.stat(tgt).st_uid, os.stat(tgt).st_gid
+    subprocess.run(['sudo', 'mount', '-o', 'loop', backing_file, tgt],
+                   check=True)
+    mount_uid, mount_gid = os.stat(tgt).st_uid, os.stat(tgt).st_gid
+    if (tgt_uid, tgt_gid) != (mount_uid, mount_gid):
+        log.debug(f'fixing owner:group ({tgt_uid}:{tgt_gid})')
+        subprocess.run(['sudo', 'chown', f'{tgt_uid}:{tgt_gid}', tgt],
+                       check=True)
+
+
+def storage_setup_wizard():
+    assert SETUP in ('auto', 'suggest', 'never')
+    if SETUP == 'never':
+        return
+    size = SIZE
+    machinesdir = MACHINES
+    if not os.path.exists(machinesdir):
+        os.mkdir(machinesdir)
+    if not is_supported(machinesdir):
+        log.warning(f'images directory {machinesdir} lacks reflink support')
+        log.warning('without it, fingertip will thrash and fill up your SSD in no time')
+        backing_file = os.path.join(CACHE, 'for-machines.xfs')
+        if not os.path.exists(backing_file):
+            if SETUP == 'suggest':
+                log.info(f'would you like to allow fingertip to allocate {size} '
+                         f'at {backing_file} '
+                         'for a reflink-enabled XFS loop mount?')
+                log.info('(set FINGERTIP_SETUP="auto" environment variable'
+                         ' to do it automatically)')
+                i = input(f'[{size}]/different size/cancel/ignore> ').strip()
+                if i == 'cancel':
+                    log.error('cancelled')
+                    sys.exit(1)
+                elif i == 'ignore':
+                    return
+                size = i or size
+            tmp = temp.disappearing_file(CACHE)
+            create_supported_fs(tmp, size)
+            os.rename(tmp, backing_file)
+
+        log.info(f'fingertip will now mount the XFS image at {backing_file}')
+        if SETUP == 'suggest':
+            i = input(f'[ok]/skip/cancel> ').strip()
+            if i == 'skip':
+                log.warning('skipping; fingertip will have no reflink superpowers')
+                log.warning('tell your SSD I\'m sorry')
+                return
+            elif i and i != 'ok':
+                log.error('cancelled')
+                sys.exit(1)
+
+        mount_supported_fs(backing_file, MACHINES)
+
+    # Schedule automatic cleanup
+    storage_schedule_cleanup()
+
+
+def storage_unmount():
+    log.plain()
+    log.info(f'unmounting {MACHINES} ...')
+    subprocess.run(['sudo', 'umount', '-l', MACHINES])
+    log.nicer()
+
+
+def storage_schedule_cleanup():
+    # Do this only if fingertip is in PATH
+    if not shutil.which("fingertip"):
+        log.warning('No `fingertip` found in PATH. Not scheduling '
+                    'automatic cleanup.')
+        return
+
+    # Skip if systemd is not available
+    if not shutil.which('systemd-run') or not shutil.which('systemctl'):
+        log.warning('It looks like systemd is not available. '
+                    'No cleanup is scheduled! If you are running out of disk, '
+                    'space, run `fingertip cleanup periodic` manually.')
+        return
+
+    # If the timer is already installed skip installation too
+    try:
+        subprocess.run(['systemctl', '--user', 'is-active', '--quiet',
+                       'fingertip-cleanup.timer'])
+        # exit code 0:
+        log.info('The systemd timer handling cleanup is already installed '
+                 'and running.')
+        return
+    except CalledProcessError as e:
+        # non-zero exit code means it is not active or not existing
+        pass
+
+    # Run twice a day
+    log.info('Scheduling cleanup twice a day at 8AM and 8PM')
+    subprocess.run(['systemd-run', '--unit=fingertip-cleanup', '--user',
+                    '--on-calendar=', '*-*-* 08,20:00:00',
+                    'fingertip', 'cleanup', 'periodic'])


### PR DESCRIPTION
On startup, check whether the CoW system is ready and if not, prompt for the setup (instead of just the warning). It also schedules automatic cleanup (using new plugin keyword `cleanup periodical`) every 12 hours if the fingertip is installed in the system (reachable through `which`).

It also allows to unmount the mounted fs using `filesystem cleanup`.