### PR TITLE
Properly terminate ssh connections

### DIFF
--- a/fingertip/plugins/backend/qemu.py
+++ b/fingertip/plugins/backend/qemu.py
@@ -332,6 +332,7 @@ class SSH:
         pkey = paramiko.ECDSAKey.from_private_key_file(self.key)
 
         def connect():
+            self.m.log.debug('Trying to connect ...')
             t = paramiko.Transport((self.host, self.port))
             t.start_client()
             return t

--- a/fingertip/plugins/backend/qemu.py
+++ b/fingertip/plugins/backend/qemu.py
@@ -345,6 +345,10 @@ class SSH:
         self._transport = transport
 
     def invalidate(self):
+        # gracefully terminate transport channel
+        if self._transport:
+            self.m.log.debug('Closing SSH session')
+            self._transport.close()
         self._transport = None
 
     def _stream_out_and_err(self, channel):

--- a/fingertip/plugins/backend/qemu.py
+++ b/fingertip/plugins/backend/qemu.py
@@ -266,12 +266,12 @@ class Monitor:
         self._expect({'return': {}})
 
     def pause(self):
+        self.vm.hooks.disrupt()
         self._execute('stop')
         r = self._expect(None)
         assert set(r.keys()) == {'timestamp', 'event'}
         assert r['event'] == 'STOP'
         self._expect({'return': {}})
-        self.vm.hooks.disrupt()
 
     def quit(self):
         self.vm.hooks.disrupt()

--- a/fingertip/plugins/os/alpine.py
+++ b/fingertip/plugins/os/alpine.py
@@ -55,6 +55,14 @@ def install_in_qemu(m):
         m.console.sendline('. /etc/profile.d/proxy.sh')
         m.console.expect_exact(m.prompt)
 
+        fqdn = m.hostname + '.fingertip.local'
+        m.console.sendline(f'echo "{m.hostname}" > /etc/hostname')
+        m.console.expect_exact(m.prompt)
+        m.console.sendline('hostname -F /etc/hostname')
+        m.console.expect_exact(m.prompt)
+        m.console.sendline(f'echo "127.0.0.1 {fqdn} {m.hostname}" > /etc/hosts')
+        m.console.expect_exact(m.prompt)
+
         m.console.sendline(f'setup-apkrepos {REPO}')
         m.console.expect_exact(m.prompt)
 

--- a/fingertip/plugins/self_test/hostname.py
+++ b/fingertip/plugins/self_test/hostname.py
@@ -6,7 +6,7 @@ import fingertip
 @fingertip.transient
 def main(m):
     with m.transient() as m:
-        r = m('hostname')
+        r = m('hostname -f')
         assert r.out.endswith('.fingertip.local\n')
         assert m('hostname -d').out == 'fingertip.local\n'
 

--- a/fingertip/plugins/self_test/ssh_terminate.py
+++ b/fingertip/plugins/self_test/ssh_terminate.py
@@ -1,0 +1,36 @@
+# Licensed under GNU General Public License v3 or later, see COPYING.
+# Copyright (c) 2020 Red Hat, Inc., see CONTRIBUTORS.
+
+import fingertip
+
+
+def check_processes(m):
+    if hasattr(m, 'console'):
+        with m:
+            # There should not be any hanging process after installation
+            m.console.sendline("ps ax | grep '[s]shd.*notty' > .sshd1")
+            m.console.expect_exact(m.prompt)
+
+            if hasattr(m, 'ssh'):
+                # debug output of all sshd processes
+                r = m("ps ax | grep -A1 '[s]shd' && echo $$")
+                assert r.retcode == 0
+                m.ssh.invalidate()
+
+            # There should not be any hanging process even after the above command
+            m.console.sendline("ps ax | grep '[s]shd.*notty' > .sshd2")
+            m.console.expect_exact(m.prompt)
+    else:
+        raise NotImplementedError()
+
+    return m
+
+
+@fingertip.transient
+def main(m):
+    m = m.apply('unseal')
+    with m.apply(check_processes).transient() as m:
+        m.log.info(m('cat .sshd1').out.strip())
+        m.log.info(m('cat .sshd2').out.strip())
+        assert m('cat .sshd1 | wc -l').out.strip() == "0"
+        assert m('cat .sshd2 | wc -l').out.strip() == "0"

--- a/fingertip/plugins/ssh.py
+++ b/fingertip/plugins/ssh.py
@@ -9,6 +9,9 @@ def main(m, no_unseal=False):
     with m.transient() as m:
         m.log.info(f'waiting for the SSH server to be up...')
         m.ssh.exec('true')
+        # terminate the ssh session not to leave any traces in vm
+        m.ssh.invalidate()
+
         m.log.info(f'starting interactive SSH session, {m.ssh.port}')
         m.log.plain()
         subprocess.run(['ssh',

--- a/test.py
+++ b/test.py
@@ -42,6 +42,7 @@ TESTS = dict(
     subsh=lambda m: m.apply('self_test.subshell'),
     wait4=lambda m: m.apply('self_test.wait_for_it'),
     scrpt=lambda m: m.apply('self_test.script'),
+    hostn=lambda m: m.apply('self_test.hostname'),
 )
 
 SKIP = (


### PR DESCRIPTION
This patch set makes sure ssh connections are properly terminated and ads test to check that.

It turned out that the offender was directly the ssh plugin and unseal step in hooks (enabling network manager).

The test will need some more love as it still hangs  even though I tried to follow the other console example tests as closely as possible.