### PR TITLE
WIP: Natural transiency

### DIFF
--- a/fingertip/expiration.py
+++ b/fingertip/expiration.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 Red Hat, Inc., see CONTRIBUTORS.
 
 import datetime
+import numbers
 import os
 import sys
 import time
@@ -13,7 +14,9 @@ def _parse(interval):
     _SUFFIXES = {'s': 1, 'm': 60, 'h': 60 * 60, 'd': 24 * 60 * 60}
     if isinstance(interval, str) and interval[-1] in _SUFFIXES:
         return float(interval[:-1]) * _SUFFIXES[interval[-1]]
-    return float(interval)
+    if isinstance(interval, numbers.Real) and not isinstance(interval, bool):
+        return float(interval)
+    raise ValueError(f'Cannot parse time interval {interval}')
 
 
 class Expiration:

--- a/fingertip/main.py
+++ b/fingertip/main.py
@@ -44,18 +44,20 @@ def main():
     first_step, *rest_of_the_steps = [parse_subcmd(*sc) for sc in subcmds]
 
     first_step_cmd, first_step_args, first_step_kwargs = first_step
-    m = fingertip.build(first_step_cmd, *first_step_args, **first_step_kwargs)
+    m = fingertip.build(first_step_cmd, *first_step_args, **first_step_kwargs,
+                        last_step=(not rest_of_the_steps))
 
-    for step_cmd, step_args, step_kwargs in rest_of_the_steps:
-        m = m.apply(step_cmd, *step_args, **step_kwargs)
+    for i, (step_cmd, step_args, step_kwargs) in enumerate(rest_of_the_steps):
+        last_step = i == len(rest_of_the_steps) - 1
+        m = m.apply(step_cmd, *step_args, **step_kwargs, last_step=last_step)
+    result_path = m
 
     fingertip.util.log.plain()
-    success_log = os.path.join(os.path.dirname(m.path), 'log.txt')
+    success_log = os.path.join(result_path, 'log.txt')
     DEBUG = os.getenv('FINGERTIP_DEBUG') == '1'
-    msg = (f'Check {success_log} for more details or set FINGERTIP_DEBUG=1'
+    msg = (f'For more details, check {success_log} or set FINGERTIP_DEBUG=1.'
            if not DEBUG else f'Logfile: {success_log}')
     fingertip.util.log.info(f'Success. {msg}')
-    m.log.finalize()
 
 
 if __name__ == '__main__':

--- a/fingertip/main.py
+++ b/fingertip/main.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 Red Hat, Inc., see CONTRIBUTORS.
 
 import itertools
+import os
 import sys
 
 import fingertip
@@ -49,6 +50,12 @@ def main():
         m = m.apply(step_cmd, *step_args, **step_kwargs)
 
     fingertip.util.log.plain()
+    success_log = os.path.join(os.path.dirname(m.path), 'log.txt')
+    DEBUG = os.getenv('FINGERTIP_DEBUG') == '1'
+    msg = (f'Check {success_log} for more details or set FINGERTIP_DEBUG=1'
+           if not DEBUG else f'Logfile: {success_log}')
+    fingertip.util.log.info(f'Success. {msg}')
+    m.log.finalize()
 
 
 if __name__ == '__main__':

--- a/fingertip/plugins/script.py
+++ b/fingertip/plugins/script.py
@@ -1,14 +1,31 @@
 # Licensed under GNU General Public License v3 or later, see COPYING.
 # Copyright (c) 2019 Red Hat, Inc., see CONTRIBUTORS.
 
+import fingertip
 
-def run(m, scriptpath, transient=False, no_unseal=False):
+
+# fingertip ... + script.run script  -  no cache, never persist, always rerun
+# fingertip ... + script.run script + ssh  -  cache just for ssh, never reuse
+# fingertip ... + script.run script --cache=1h  -  try to cache for 1h at most
+# fingertip ... + script.run script --cache=1h + ssh  -  try reusing the cache
+
+
+def _should_run_be_transient(scriptpath, cache=0, no_unseal=False):
+    return False if cache else 'last'
+
+
+@fingertip.transient(when=_should_run_be_transient)
+def run(m, scriptpath, cache=0, no_unseal=False):
     m.log.debug(f'Plugin: script, scriptpath: {scriptpath}, '
-                f'transient: {transient}, no_unseal: {no_unseal}')
+                f'cache: {cache}, no_unseal: {no_unseal}')
     m = m if no_unseal else m.apply('unseal')
     scriptname = 'uploaded_script'
-    m.expiration.depend_on_a_file(scriptpath)
+
     with m:
+        if cache is not True:
+            m.expiration.cap(cache)
+        m.expiration.depend_on_a_file(scriptpath)
+
         m.log.debug(f'uploading {scriptpath} into {scriptname}')
         m.ssh.upload(scriptpath, dst=scriptname)
         m.log.debug(f'uploaded {scriptpath} into {scriptname}')
@@ -16,5 +33,4 @@ def run(m, scriptpath, transient=False, no_unseal=False):
         m.log.plain()
         m(f'./{scriptname}')
         m.log.nicer()
-    if not transient:
-        return m
+    return m

--- a/fingertip/util/log.py
+++ b/fingertip/util/log.py
@@ -175,7 +175,7 @@ class Sublogger:
         reflink.auto(self.path, t)
         home = os.path.expanduser('~')
         t = t if not t.startswith(home) else t.replace(home, '~')
-        m = (f'Check {t} for more details or set FINGERTIP_DEBUG=1'
+        m = (f'For an intermediate log, check {t} or set FINGERTIP_DEBUG=1.'
              if not DEBUG else f'Logfile: {t}')
         sys.stderr.write(m + '\n')
 

--- a/test.py
+++ b/test.py
@@ -51,6 +51,11 @@ SKIP = (
     ('podman_alpine', 'subsh'),  # shell poorly snapshottable with CRIU (ash)
     ('podman_ubuntu', 'wait4'),  # shell poorly snapshottable with CRIU (dash)
     ('podman_ubuntu', 'subsh'),  # shell poorly snapshottable with CRIU (dash)
+    ('podman_centos', 'scrpt'),  # needs ssh.upload
+    ('podman_fedora', 'scrpt'),  # needs ssh.upload
+    ('podman_fedorO', 'scrpt'),  # needs ssh.upload
+    ('podman_alpine', 'scrpt'),  # needs ssh.upload
+    ('podman_ubuntu', 'scrpt'),  # needs ssh.upload
 )
 
 for base_name, base in BASES.items():


### PR DESCRIPTION
Implement 'natural' transiency rules for `script.run`.
I'm not entirely sure I understand the user expectations right, but that's my understanding after yesterday's discussion with @tomato42:

```
$ fingertip ... + script.run script  -  no cache, never persist, always rerun
$ fingertip ... + script.run script + ssh  -  cache just for ssh, never reuse
$ fingertip ... + script.run script --cache=1h  -  try to cache for 1h at most
$ fingertip ... + script.run script --cache=1h + ssh  -  try reusing the cache
```