### PR TITLE
fingertip-containerized: fix cwd and missing deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN dnf -y --setopt=install_weak_deps=False --best install \
 	python3-pyxdg \
 	python3-requests \
 	python3-requests-mock \
+	python3-rangehttpserver \
+	python3-GitPython \
 	qemu-img \
 	qemu-kvm-core \
 	&& dnf clean all
@@ -26,4 +28,4 @@ RUN dnf -y --setopt=install_weak_deps=False --best install \
 RUN mkdir -p /user-home/.cache/fingertip /containerized-fingertip /cwd
 ENV HOME /user-home
 RUN chmod -R 777 /user-home /cwd
-WORKDIR /containerized-fingertip/cwd
+WORKDIR /cwd


### PR DESCRIPTION
Correct WORKDIR should be /cwd (a directory where current directory is uploaded). Previously used /containerized-fingertip/cwd does not actually exist. Moreover, to run properly python3-rangehttpserver and python3-GitPython are needed.