### PR TITLE
Support aarch64 with UEFI on Fedora, fix os.fedora to support aarch64

### DIFF
--- a/fingertip/plugins/backend/qemu.py
+++ b/fingertip/plugins/backend/qemu.py
@@ -36,7 +36,8 @@ QEMU_COMMON_ARGS = ['-enable-kvm', '-cpu', 'host',
                     '-nographic',
                     '-object', 'rng-random,id=rng0,filename=/dev/urandom',
                     '-device', 'virtio-balloon',
-                    '-device', 'virtio-rng-pci,rng=rng0']
+                    '-device', 'virtio-rng-pci,rng=rng0',
+                    '-device', 'pcie-root-port,id=pcie-root,slot=0']
 
 
 def main(arch='x86_64', ram_min='1G', ram_size='1G', ram_max='4G',
@@ -503,7 +504,7 @@ class Monitor:
             self._expect({'return': {}})
         with self._command_execution_lock:
             self._execute('device_add',
-                          driver=driver, drive=drive_name, id=dev_name)
+                          driver=driver, drive=drive_name, id=dev_name, bus='pcie-root')
             self._expect({'return': {}})
 
     def detach_disk(self, drive_name, dev_name):

--- a/fingertip/plugins/os/alpine.py
+++ b/fingertip/plugins/os/alpine.py
@@ -8,7 +8,7 @@ from fingertip.util import path
 
 
 MIRROR = 'http://dl-cdn.alpinelinux.org/alpine'
-ISO = MIRROR + '/v3.20/releases/x86_64/alpine-virt-3.20.2-x86_64.iso'
+ISO = MIRROR + '/v3.20/releases/%ARCH%/alpine-virt-3.20.2-%ARCH%.iso'
 REPO = MIRROR + '/v3.20/main/'
 
 
@@ -32,8 +32,9 @@ def main(m=None):
 
 
 def install_in_qemu(m):
-    iso_file = os.path.join(m.path, os.path.basename(ISO))
-    m.http_cache.fetch(ISO, iso_file)
+    iso = ISO.replace('%ARCH%', m.arch)
+    iso_file = os.path.join(m.path, os.path.basename(iso))
+    m.http_cache.fetch(iso, iso_file)
 
     ssh_key_fname = path.fingertip('ssh_key', 'fingertip.pub')
     with open(ssh_key_fname) as f:

--- a/rpm/fingertip.template.spec
+++ b/rpm/fingertip.template.spec
@@ -36,6 +36,10 @@ Requires:	qemu-img
 Requires:	rsync
 Requires:	util-linux
 Requires:	xfsprogs
+%ifarch aarch64
+# aarch64 VMs must be booted with UEFI; require the package that provides the UEFI firmware
+Requires:   edk2-aarch64
+%endif
 Recommends:	duperemove
 Recommends:	createrepo_c
 Recommends:	podman

--- a/rpm/fingertip.template.spec
+++ b/rpm/fingertip.template.spec
@@ -31,7 +31,7 @@ Requires:	python3-rangehttpserver
 Requires:	python3-requests
 Requires:	python3-requests-mock
 Requires:	python3-ruamel-yaml
-Requires:	qemu-system-x86-core
+Requires:	qemu-kvm
 Requires:	qemu-img
 Requires:	rsync
 Requires:	util-linux


### PR DESCRIPTION
I thought about how to test this, but as of now, GitHub does not offer arm64 Linux runners to non-paying customers; this is expected to change in Q1, though, at which point we can probably add some CI check to verify that this works (unless the GitHub runners won't support nested virtualization, which we don't know yet).