### PR TITLE
util.http_cache: Log reason for connection errors

### DIFF
--- a/fingertip/util/http_cache.py
+++ b/fingertip/util/http_cache.py
@@ -172,10 +172,10 @@ class HTTPCache:
                             assert len(data) == length
                 except BrokenPipeError:
                     error = f'Upwards broken pipe for {meth} {uri}'
-                except ConnectionResetError:
-                    error = f'Upwards connection reset for {meth} {uri}'
-                except requests.exceptions.ConnectionError:
-                    error = f'Upwards connection error for {meth} {uri}'
+                except ConnectionResetError as connreseterr:
+                    error = f'Upwards connection reset for {meth} {uri} ({connreseterr})'
+                except requests.exceptions.ConnectionError as connerr:
+                    error = f'Upwards connection error for {meth} {uri} ({connerr})'
                 if error:
                     # delay a re-request
                     if retries:


### PR DESCRIPTION
Occasionally the reason is something that isn't temporary (e.g., an invalid TLS certificate) and it's actually helpful to be able to see the error message somewhere to identify and fix the problem.